### PR TITLE
Provide only necessary info from distribution API when module is on disk

### DIFF
--- a/src/DistributionApi.php
+++ b/src/DistributionApi.php
@@ -75,17 +75,22 @@ class DistributionApi
         $modules = [];
 
         foreach ($response as $name => $module) {
-            $modules[] = [
+            $attributes = [
                 'name' => $name,
-                'displayName' => $module['display_name'],
-                'description' => $module['description'],
-                'version' => $module['version'],
                 'version_available' => $module['version'],
-                'author' => $module['author'],
                 'download_url' => $module['download_url'],
-                'img' => $module['icon'],
-                'tab' => $module['tab'],
             ];
+            if (!$this->isModuleOnDisk($name)) {
+                $attributes += [
+                    'displayName' => $module['display_name'],
+                    'description' => $module['description'],
+                    'version' => $module['version'],
+                    'author' => $module['author'],
+                    'img' => $module['icon'],
+                    'tab' => $module['tab'],
+                ];
+            }
+            $modules[] = $attributes;
         }
 
         return $modules;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR aims to not provide some information from the distribution API if the module is on the disk, especially the `version` that is displayed in the module manager.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#28436
| How to test?      | Please see PrestaShop/PrestaShop#28436
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
