### PR TITLE
Add shop information to API calls

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -44,12 +44,16 @@ services:
     factory: [ '@distributionapiclient.circuit_breaker.factory', 'create' ]
     arguments: [ '@distributionapiclient.circuit_breaker.settings' ]
 
+  distributionapiclient.shop_data_provider:
+    class: PrestaShop\Module\DistributionApiClient\ShopDataProvider
+
   distributionapiclient.distribution_api:
     class: PrestaShop\Module\DistributionApiClient\DistributionApi
     arguments:
       - '@distributionapiclient.circuit_breaker'
       - '@prestashop.module.factory.sourcehandler'
       - '@prestashop.adapter.data_provider.module'
+      - '@distributionapiclient.shop_data_provider'
       - "@=service('prestashop.core.foundation.version').getSemVersion()"
       - '%ps_cache_dir%/downloads'
     public: true

--- a/config/services.yml
+++ b/config/services.yml
@@ -44,7 +44,7 @@ services:
     factory: [ '@distributionapiclient.circuit_breaker.factory', 'create' ]
     arguments: [ '@distributionapiclient.circuit_breaker.settings' ]
 
-  distributionapiclient.shop_data_provider:
+  PrestaShop\Module\DistributionApiClient\ShopDataProvider:
     class: PrestaShop\Module\DistributionApiClient\ShopDataProvider
 
   distributionapiclient.distribution_api:
@@ -53,7 +53,7 @@ services:
       - '@distributionapiclient.circuit_breaker'
       - '@prestashop.module.factory.sourcehandler'
       - '@prestashop.adapter.data_provider.module'
-      - '@distributionapiclient.shop_data_provider'
+      - '@PrestaShop\Module\DistributionApiClient\ShopDataProvider'
       - "@=service('prestashop.core.foundation.version').getSemVersion()"
       - '%ps_cache_dir%/downloads'
     public: true

--- a/src/DistributionApi.php
+++ b/src/DistributionApi.php
@@ -123,7 +123,7 @@ class DistributionApi
     /**
      * Extracts the download URL from a module data structure
      *
-     * @param array{download_url: string} $module Module data structure, from API response
+     * @param array{download_url?: string} $module Module data structure, from API response
      *
      * @return string Download URL
      */

--- a/src/DistributionApi.php
+++ b/src/DistributionApi.php
@@ -25,6 +25,7 @@ namespace PrestaShop\Module\DistributionApiClient;
 use PrestaShop\CircuitBreaker\Contract\CircuitBreakerInterface;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerFactory;
+use RuntimeException;
 
 class DistributionApi
 {
@@ -50,10 +51,16 @@ class DistributionApi
     /** @var string */
     private $downloadDirectory;
 
+    /**
+     * @var ShopDataProvider
+     */
+    private $shopDataProvider;
+
     public function __construct(
         CircuitBreakerInterface $circruitBreaker,
         SourceHandlerFactory $sourceHandlerFactory,
         ModuleDataProvider $moduleDataProvider,
+        ShopDataProvider $shopDataProvider,
         string $prestashopVersion,
         string $downloadDirectory
     ) {
@@ -62,6 +69,7 @@ class DistributionApi
         $this->moduleDataProvider = $moduleDataProvider;
         $this->prestashopVersion = $prestashopVersion;
         $this->downloadDirectory = rtrim($downloadDirectory, '/');
+        $this->shopDataProvider = $shopDataProvider;
     }
 
     /**
@@ -69,7 +77,7 @@ class DistributionApi
      */
     public function getModuleList(): array
     {
-        $endpoint = self::API_ENDPOINT . '/modules/' . $this->prestashopVersion;
+        $endpoint = $this->getModulesListUrl();
         $response = $this->getResponse($endpoint);
 
         $modules = [];
@@ -113,17 +121,31 @@ class DistributionApi
     }
 
     /**
+     * Extracts the download URL from a module data structure
+     *
+     * @param array{download_url: string} $module Module data structure, from API response
+     *
+     * @return string Download URL
+     */
+    protected function getModuleDownloadUrl(array $module): string
+    {
+        if (!isset($module['download_url'])) {
+            throw new RuntimeException('Could not determine URL to download the module from');
+        }
+
+        return $this->addShopInfoToUrl($module['download_url']);
+    }
+
+    /**
      * @param array<string, string> $module
      *
      * @return void
      */
     private function doDownload(array $module): void
     {
-        if (!isset($module['download_url'])) {
-            return;
-        }
+        $downloadUrl = $this->getModuleDownloadUrl($module);
 
-        $moduleZip = file_get_contents($module['download_url']);
+        $moduleZip = file_get_contents($downloadUrl);
 
         $downloadPath = $this->getModuleDownloadDirectory($module['name']);
         $this->createDownloadDirectoryIfNeeded($downloadPath);
@@ -157,5 +179,33 @@ class DistributionApi
         $response = json_decode($this->circruitBreaker->call($endpoint), true) ?: [];
 
         return $response;
+    }
+
+    /**
+     * Returns the URL to the list of modules for this version
+     *
+     * @return string
+     */
+    private function getModulesListUrl(): string
+    {
+        $url = self::API_ENDPOINT . '/modules/' . $this->prestashopVersion;
+
+        return $this->addShopInfoToUrl($url);
+    }
+
+    /**
+     * Adds shop information to an URL
+     *
+     * @param string $url API endpoint
+     *
+     * @return string Modified URL
+     */
+    private function addShopInfoToUrl(string $url): string
+    {
+        $shopUrl = urlencode($this->shopDataProvider->getShopUrl());
+
+        $separator = (strpos($url, '?') !== false) ? '&' : '?';
+
+        return sprintf('%s%sshop_domain=%s', $url, $separator, $shopUrl);
     }
 }

--- a/src/ShopDataProvider.php
+++ b/src/ShopDataProvider.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\DistributionApiClient;
+
+use Context;
+
+/**
+ * Provides information about the shop, to be added to API calls
+ */
+class ShopDataProvider
+{
+    public function getShopUrl()
+    {
+        return Context::getContext()->link->getBaseLink();
+    }
+}

--- a/src/ShopDataProvider.php
+++ b/src/ShopDataProvider.php
@@ -28,7 +28,12 @@ use Context;
  */
 class ShopDataProvider
 {
-    public function getShopUrl()
+    /**
+     * Returns the default URL to shop's Front office
+     *
+     * @return string
+     */
+    public function getShopUrl(): string
     {
         return Context::getContext()->link->getBaseLink();
     }

--- a/src/ShopDataProvider.php
+++ b/src/ShopDataProvider.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 namespace PrestaShop\Module\DistributionApiClient;
 
 use Context;
+use Link;
+use RuntimeException;
 
 /**
  * Provides information about the shop, to be added to API calls
@@ -35,6 +37,11 @@ class ShopDataProvider
      */
     public function getShopUrl(): string
     {
-        return Context::getContext()->link->getBaseLink();
+        $context = Context::getContext();
+        if (!$context instanceof Context || !$context->link instanceof Link) {
+            throw new RuntimeException('Unable to retrieve the contextual Link instance');
+        }
+
+        return $context->link->getBaseLink();
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Added shop URL as a parameter to API calls
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #13
| How to test?      | Proof of change is shown on screenshots below.<br>Non regression test:<br>(1) Remove a native module and make sure it is removed form disk (eg `statsbestsuppliers`).<br>(2) See the module showing up on the list, ready to be installed (means the API call for the list of modules works).<br>(3) It is possible to download the module by clicking on install (means API call for the download works).

The URL for the list of native modules now looks like this:
<img width="719" alt="Screenshot 2023-01-03 at 15 26 14" src="https://user-images.githubusercontent.com/1009343/210382786-497e4676-a854-4147-91c5-ea2655c98e83.png">
⚠️ Note that this URL above doesn't exist yet on the server. Replace 8.0.1 by 8.0.0 for it to work.

The URL to download a module now looks like this:
<img width="1061" alt="Screenshot 2023-01-03 at 15 48 57" src="https://user-images.githubusercontent.com/1009343/210382894-52332c15-faf7-43f2-8eba-3d773fd3a168.png">
