### PR TITLE
Option to opt-out/in to sending shop url to the API

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -1,5 +1,6 @@
 parameters:
   ps_cache_dir: !php/const _PS_CACHE_DIR_
+  distributionapiclient_config_key: !php/const Ps_Distributionapiclient::SEND_SHOP_URL
 
 services:
   distributionapiclient.cache.filesystem.adapter:
@@ -56,4 +57,5 @@ services:
       - '@PrestaShop\Module\DistributionApiClient\ShopDataProvider'
       - "@=service('prestashop.core.foundation.version').getSemVersion()"
       - '%ps_cache_dir%/downloads'
+      - "@=service('prestashop.adapter.legacy.configuration').getBoolean(container.getParameter('distributionapiclient_config_key'))"
     public: true

--- a/ps_distributionapiclient.php
+++ b/ps_distributionapiclient.php
@@ -32,21 +32,29 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 
 class Ps_Distributionapiclient extends Module
 {
+    /** @var string Name of the submit button */
+    public const SUBMIT_NAME = 'update-configuration';
+
+    /** @var string Config key for the setting */
+    public const SEND_SHOP_URL = 'DISTRIBUTIONAPI_SEND_SHOP_URL';
+
     public function __construct()
     {
         $this->name = 'ps_distributionapiclient';
         $this->displayName = $this->trans('Distribution API Client', [], 'Modules.Distributionapiclient.Admin');
         $this->description = $this->trans('Download and upgrade PrestaShop\'s native modules.', [], 'Modules.Distributionapiclient.Admin');
         $this->author = 'PrestaShop';
-        $this->version = '1.0.3';
+        $this->version = '1.1.0';
         $this->ps_versions_compliancy = ['min' => '8.0.0', 'max' => _PS_VERSION_];
         $this->tab = 'market_place';
+        $this->bootstrap = true;
         parent::__construct();
     }
 
     public function install(): bool
     {
         return parent::install()
+            && Configuration::updateValue(static::SEND_SHOP_URL, 1)
             && $this->registerHook('actionListModules')
             && $this->registerHook('actionBeforeInstallModule')
             && $this->registerHook('actionBeforeUpgradeModule')
@@ -96,5 +104,101 @@ class Ps_Distributionapiclient extends Module
         $distributionApi = $this->get('distributionapiclient.distribution_api');
 
         return $distributionApi;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent()
+    {
+        $html = $this->renderForm();
+
+        if (Tools::isSubmit(static::SUBMIT_NAME)) {
+            Configuration::updateValue(
+                static::SEND_SHOP_URL,
+                Tools::getValue(static::SEND_SHOP_URL)
+            );
+
+            /** @var Link $link */
+            $link = $this->context->link;
+            Tools::redirectAdmin($link->getAdminLink('AdminModules') . '&configure=' . $this->name . '&conf=6');
+        }
+
+        return $html;
+    }
+
+    /**
+     * @return string
+     */
+    protected function renderForm()
+    {
+        $fieldsValue = [
+            static::SEND_SHOP_URL => Tools::getValue(
+                static::SEND_SHOP_URL,
+                Configuration::get(static::SEND_SHOP_URL)
+            ),
+        ];
+        $form = [
+            'form' => [
+                'legend' => [
+                    'title' => $this->trans('Parameters', [], 'Modules.Distributionapiclient.Admin'),
+                    'icon' => 'icon-envelope',
+                ],
+                'input' => [
+                    [
+                        'type' => 'switch',
+                        'label' => $this->trans(
+                            'Share this store\'s public URL with PrestaShop',
+                            [],
+                            'Modules.Distributionapiclient.Admin'
+                        ),
+                        'desc' => $this->trans(
+                            "If this option is enabled, the URL to your store's front office will be sent to PrestaShop alongside distribution API requests. Sharing this information with us helps better understand how PrestaShop software is used in the ecosystem.",
+                            [],
+                            'Modules.Distributionapiclient.Admin'
+                        ),
+                        'name' => self::SEND_SHOP_URL,
+                        'is_bool' => true,
+                        'required' => true,
+                        'values' => [
+                            [
+                                'id' => self::SEND_SHOP_URL . '_on',
+                                'value' => 1,
+                                'label' => $this->trans('Enabled', [], 'Admin.Global'),
+                            ],
+                            [
+                                'id' => self::SEND_SHOP_URL . '_off',
+                                'value' => 0,
+                                'label' => $this->trans('Disabled', [], 'Admin.Global'),
+                            ],
+                        ],
+                    ],
+                ],
+                'submit' => [
+                    'name' => self::SUBMIT_NAME,
+                    'title' => $this->trans('Save', [], 'Admin.Actions'),
+                ],
+            ],
+        ];
+        $helper = new HelperForm();
+        $lang = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $helper->default_form_language = $lang->id;
+        $helper->submit_action = self::SUBMIT_NAME;
+        /** @var Link $link */
+        $link = $this->context->link;
+        $helper->currentIndex = $link->getAdminLink('AdminModules') . '&configure=' . $this->name;
+        $helper->token = Tools::getAdminTokenLite('AdminModules');
+
+        /** @var AdminController $adminController */
+        $adminController = $this->context->controller;
+        /** @var Language $language */
+        $language = $this->context->language;
+        $helper->tpl_vars = [
+            'fields_value' => $fieldsValue,
+            'languages' => $adminController->getLanguages(),
+            'id_language' => $language->id,
+        ];
+
+        return $helper->generateForm([$form]);
     }
 }

--- a/src/DistributionApi.php
+++ b/src/DistributionApi.php
@@ -51,6 +51,9 @@ class DistributionApi
     /** @var string */
     private $downloadDirectory;
 
+    /** @var bool */
+    private $shouldAddShopUrl;
+
     /**
      * @var ShopDataProvider
      */
@@ -62,7 +65,8 @@ class DistributionApi
         ModuleDataProvider $moduleDataProvider,
         ShopDataProvider $shopDataProvider,
         string $prestashopVersion,
-        string $downloadDirectory
+        string $downloadDirectory,
+        bool $shouldAddShopUrl
     ) {
         $this->circruitBreaker = $circruitBreaker;
         $this->sourceHandlerFactory = $sourceHandlerFactory;
@@ -70,6 +74,7 @@ class DistributionApi
         $this->prestashopVersion = $prestashopVersion;
         $this->downloadDirectory = rtrim($downloadDirectory, '/');
         $this->shopDataProvider = $shopDataProvider;
+        $this->shouldAddShopUrl = (bool) $shouldAddShopUrl;
     }
 
     /**
@@ -193,6 +198,11 @@ class DistributionApi
         return $this->addShopInfoToUrl($url);
     }
 
+    private function shouldAddShopUrl(): bool
+    {
+        return $this->shouldAddShopUrl;
+    }
+
     /**
      * Adds shop information to an URL
      *
@@ -202,6 +212,10 @@ class DistributionApi
      */
     private function addShopInfoToUrl(string $url): string
     {
+        if (!$this->shouldAddShopUrl()) {
+            return $url;
+        }
+
         $shopUrl = urlencode($this->shopDataProvider->getShopUrl());
 
         $separator = (strpos($url, '?') !== false) ? '&' : '?';

--- a/upgrade/upgrade-1.1.0.php
+++ b/upgrade/upgrade-1.1.0.php
@@ -1,0 +1,30 @@
+
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_1_1_0()
+{
+    Configuration::updateValue(Ps_Distributionapiclient::SEND_SHOP_URL, 1);
+
+    return true;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Option to opt-out/in to sending shop url to the API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/ps_distributionapiclient/issues/16.
| How to test?      | detailed instruction below
| Possible impacts? | We need to discuss if the default value should be 1 after an upgrade of the module.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

0. Make sure you're in the debug mode
1. Edit modules/ps_distributionapiclient/src/DistributionApi.php
2. After line `86` use `dump($endpoint);`
3. Visit Module manager, you'll see a new icon in the debug toolbar with information about the current endpoint.
4. With the option enabled, you should see a URL with added shop domain, with disabled, you should see a URL without a domain.
