### PR TITLE
update ps version compliancy minimum version

### DIFF
--- a/ps_distributionapiclient.php
+++ b/ps_distributionapiclient.php
@@ -39,7 +39,7 @@ class Ps_Distributionapiclient extends Module
         $this->description = $this->trans('Download and upgrade PrestaShop\'s native modules.', [], 'Modules.Distributionapiclient.Admin');
         $this->author = 'PrestaShop';
         $this->version = '1.0.3';
-        $this->ps_versions_compliancy = ['min' => '8.0.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '8.0.2', 'max' => _PS_VERSION_];
         $this->tab = 'market_place';
         parent::__construct();
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | updating the min `ps_versions_compliancy` to `8.0.2` because upgrading to `1.0.3` in `< 8.0.2` would fail
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | none
| Sponsor company   | PrestaShop SA
| How to test?      | none