### PR TITLE
Migrate deprecated DoctrineProvider to new one

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -10,7 +10,8 @@ services:
       - '%ps_cache_dir%/distribution-api'
 
   distributionapiclient.cache.provider:
-    class: Symfony\Component\Cache\DoctrineProvider
+    class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+    factory: [ Doctrine\Common\Cache\Psr6\DoctrineProvider, wrap ]
     arguments:
       - '@distributionapiclient.cache.filesystem.adapter'
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR is a preparation to migrate to Symfony 6 soon.<br>
Here, we migrate `DoctrineProvider` to new one.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33994
| Sponsor company   | PrestaShop SA
| How to test?      | CI 🟢
